### PR TITLE
Register Namespace_ into StmtsAwareInterface

### DIFF
--- a/patches/nikic-php-parser-lib-phpparser-node-stmt-namespace-php.patch
+++ b/patches/nikic-php-parser-lib-phpparser-node-stmt-namespace-php.patch
@@ -1,0 +1,13 @@
+--- /dev/null
++++ ../lib/PhpParser/Node/Stmt/Namespace_.php
+@@ -3,8 +3,9 @@
+ namespace PhpParser\Node\Stmt;
+
+ use PhpParser\Node;
++use Rector\Core\Contract\PhpParser\Node\StmtsAwareInterface;
+
+-class Namespace_ extends Node\Stmt
++class Namespace_ extends Node\Stmt implements StmtsAwareInterface
+ {
+     /** @var Node\Stmt[] Statements */
+     public $stmts;


### PR DESCRIPTION
This is to handle like in PR:

- https://github.com/rectorphp/rector-src/pull/2824

but for direct namespace and then switch:

```php
namespace test;

$data = 'value';

switch ($data) {
        case Lexer::T_DELETE:
            $statement = deleteStatement();
            break;

        default:
            $statement = syntaxError('SELECT, UPDATE or DELETE');
            break;
}

echo $statement;
```